### PR TITLE
Nissix plugin scope-packages on @wix/http2-test

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "@wix/wix-express-require-https": "latest",
     "axios": "^0.19.0",
     "babel-runtime": "^6.26.0",
-    "bootstrap-hot-loader": "^3.19.3",
+    "@wix/bootstrap-hot-loader": "^3.19.3",
     "express": "~4.15.0",
     "i18next": "^11.6.0",
     "prop-types": "~15.6.0",
@@ -37,7 +37,7 @@
     "react-dom": "16.8.0",
     "react-i18next": "^7.11.0",
     "source-map-support": "^0.5.11",
-    "yoshi-template-intro": "^4.1.0"
+    "@wix/yoshi-template-intro": "^4.1.0"
   },
   "devDependencies": {
     "@wix/fedops-logger": "^5.0.0",
@@ -46,7 +46,7 @@
     "jest-yoshi-preset": "^4.1.0",
     "puppeteer": "^1.1.0",
     "react-testing-library": "^6.0.2",
-    "yoshi": "^4.1.0",
+    "@wix/yoshi": "^4.1.0",
     "yoshi-style-dependencies": "^4.1.0",
     "@wix/wix-bootstrap-testkit": "latest",
     "@wix/wix-config-emitter": "latest"

--- a/src/components/App/App.js
+++ b/src/components/App/App.js
@@ -17,7 +17,7 @@ class App extends React.Component {
   /* <-- Please also remove `yoshi-template-intro` from your package.json */
   state = {};
   async componentDidMount() {
-    const { default: TemplateIntro } = await import('yoshi-template-intro');
+    const { default: TemplateIntro } = await import('@wix/yoshi-template-intro');
     this.setState({ TemplateIntro });
   } /* --> */
 

--- a/src/server.js
+++ b/src/server.js
@@ -1,6 +1,6 @@
 import wixExpressCsrf from '@wix/wix-express-csrf';
 import wixExpressRequireHttps from '@wix/wix-express-require-https';
-import { hot } from 'bootstrap-hot-loader';
+import { hot } from '@wix/bootstrap-hot-loader';
 
 // This function is the main entry for our server. It accepts an express Router
 // (see http://expressjs.com) and attaches routes and middlewares to it.

--- a/wallaby.js
+++ b/wallaby.js
@@ -1,1 +1,1 @@
-module.exports = require('yoshi/config/wallaby-jest');
+module.exports = require('@wix/yoshi/config/wallaby-jest');


### PR DESCRIPTION
Hi, I'm Nissix, the automated PR bot!

Wix is moving its internal packages to the @wix scope (but still in the internal registry). Publishing new unscoped internal packages is no longer allowed, and all existing packages are moving to @wix. This means changing package names, and also all usages of those packages to their @wix scope version.

This PR is an automatic codemod that moves all of your packages to @wix scope, and changes any usages (`pacakge.json`, imports, requires, etc..) to their @wix version.

| :bangbang: | This codemod is best-effort! Meaning it may not have found and fixed all usages, but it did change your package.jsons. So go over the changes carefully and test this version carefully  |
| :--------: | :----------------------------------------------------------------------------------------------------- |

If you want to know why we don't support publishing unscoped to the internal registry, check out this article on [Dependency Confusion](https://medium.com/@alex.birsan/dependency-confusion-4a5d60fec610)

If you are unsure, need help or have questions, reach us at #wix-scope-migration

Error Log:
npx: installed 234 in 8.513s
npm WARN deprecated @zeit/webpack-asset-relocator-loader@0.8.0: "@zeit/webpack-asset-relocator-loader" is deprecated in favor of "@vercel/webpack-asset-relocator-loader".
npm WARN deprecated tslint@6.1.3: TSLint has been deprecated in favor of ESLint. Please see https://github.com/palantir/tslint/issues/4534 for more information.
npm WARN deprecated chokidar@2.1.8: Chokidar 2 will break on node v14+. Upgrade to chokidar 3 with 15x less dependencies.
npm WARN deprecated babel-eslint@10.1.0: babel-eslint is now @babel/eslint-parser. This package will no longer receive updates.
npm WARN deprecated @types/joi@17.2.3: This is a stub types definition. joi provides its own type definitions, so you do not need this installed.
npm WARN deprecated node-pre-gyp@0.15.0: Please upgrade to @mapbox/node-pre-gyp: the non-scoped node-pre-gyp package is deprecated and only the @mapbox scoped package will recieve updates in the future
npm WARN deprecated node-pre-gyp@0.16.0: Please upgrade to @mapbox/node-pre-gyp: the non-scoped node-pre-gyp package is deprecated and only the @mapbox scoped package will recieve updates in the future
node-pre-gyp WARN Using request for node-pre-gyp https download 
node-pre-gyp WARN Using request for node-pre-gyp https download 
npm WARN optional SKIPPING OPTIONAL DEPENDENCY: fsevents@~2.3.1 (node_modules/yoshi-common/node_modules/chokidar/node_modules/fsevents):
npm WARN notsup SKIPPING OPTIONAL DEPENDENCY: Unsupported platform for fsevents@2.3.2: wanted {"os":"darwin","arch":"any"} (current: {"os":"linux","arch":"x64"})
npm WARN optional SKIPPING OPTIONAL DEPENDENCY: fsevents@~2.3.1 (node_modules/yoshi-webpack-utils/node_modules/watchpack/node_modules/chokidar/node_modules/fsevents):
npm WARN notsup SKIPPING OPTIONAL DEPENDENCY: Unsupported platform for fsevents@2.3.2: wanted {"os":"darwin","arch":"any"} (current: {"os":"linux","arch":"x64"})
npm WARN optional SKIPPING OPTIONAL DEPENDENCY: fsevents@~2.3.1 (node_modules/yoshi-command-lint/node_modules/chokidar/node_modules/fsevents):
npm WARN notsup SKIPPING OPTIONAL DEPENDENCY: Unsupported platform for fsevents@2.3.2: wanted {"os":"darwin","arch":"any"} (current: {"os":"linux","arch":"x64"})
npm WARN optional SKIPPING OPTIONAL DEPENDENCY: fsevents@~2.3.1 (node_modules/yoshi-flow-legacy/node_modules/chokidar/node_modules/fsevents):
npm WARN notsup SKIPPING OPTIONAL DEPENDENCY: Unsupported platform for fsevents@2.3.2: wanted {"os":"darwin","arch":"any"} (current: {"os":"linux","arch":"x64"})
npm WARN optional SKIPPING OPTIONAL DEPENDENCY: fsevents@~2.3.1 (node_modules/yoshi-config-compat/node_modules/chokidar/node_modules/fsevents):
npm WARN notsup SKIPPING OPTIONAL DEPENDENCY: Unsupported platform for fsevents@2.3.2: wanted {"os":"darwin","arch":"any"} (current: {"os":"linux","arch":"x64"})
npm WARN optional SKIPPING OPTIONAL DEPENDENCY: fsevents@~2.3.1 (node_modules/yoshi-server-tools/node_modules/chokidar/node_modules/fsevents):
npm WARN notsup SKIPPING OPTIONAL DEPENDENCY: Unsupported platform for fsevents@2.3.2: wanted {"os":"darwin","arch":"any"} (current: {"os":"linux","arch":"x64"})
npm WARN optional SKIPPING OPTIONAL DEPENDENCY: fsevents@~2.3.1 (node_modules/yoshi-flow-app/node_modules/chokidar/node_modules/fsevents):
npm WARN notsup SKIPPING OPTIONAL DEPENDENCY: Unsupported platform for fsevents@2.3.2: wanted {"os":"darwin","arch":"any"} (current: {"os":"linux","arch":"x64"})
npm WARN optional SKIPPING OPTIONAL DEPENDENCY: fsevents@~2.3.1 (node_modules/yoshi-flow-monorepo/node_modules/chokidar/node_modules/fsevents):
npm WARN notsup SKIPPING OPTIONAL DEPENDENCY: Unsupported platform for fsevents@2.3.2: wanted {"os":"darwin","arch":"any"} (current: {"os":"linux","arch":"x64"})
npm WARN optional SKIPPING OPTIONAL DEPENDENCY: fsevents@~2.3.1 (node_modules/@wix/yoshi/node_modules/chokidar/node_modules/fsevents):
npm WARN notsup SKIPPING OPTIONAL DEPENDENCY: Unsupported platform for fsevents@2.3.2: wanted {"os":"darwin","arch":"any"} (current: {"os":"linux","arch":"x64"})
npm WARN @wix/wix-bootstrap-hadron@1.0.1611 requires a peer of express@>=4.17.0 but none is installed. You must install peer dependencies yourself.
npm WARN @wix/wix-bootstrap-ng@1.0.4957 requires a peer of express@>=4.17.0 but none is installed. You must install peer dependencies yourself.
npm WARN @wix/yoshi-template-intro@4.276.0 requires a peer of prop-types@~15.7.0 but none is installed. You must install peer dependencies yourself.
npm WARN @wix/yoshi-template-intro@4.276.0 requires a peer of react@16.13.1 but none is installed. You must install peer dependencies yourself.
npm WARN @wix/yoshi-template-intro@4.276.0 requires a peer of react-dom@16.13.1 but none is installed. You must install peer dependencies yourself.
npm WARN @wix/static-overrides-express@1.0.88 requires a peer of @wix/wix-bootstrap-api@latest but none is installed. You must install peer dependencies yourself.
npm WARN @wix/static-overrides-express@1.0.88 requires a peer of @wix/wix-grpc-testkit@latest but none is installed. You must install peer dependencies yourself.
npm WARN @wix/wnp-bootstrap-composer@0.1.4115 requires a peer of express@>=4.17.0 but none is installed. You must install peer dependencies yourself.
npm WARN @wix/wix-express-metering@0.1.1553 requires a peer of express@>=4.17.0 but none is installed. You must install peer dependencies yourself.
npm WARN @wix/wnp-bootstrap-management@1.0.1862 requires a peer of express@>=4.17.0 but none is installed. You must install peer dependencies yourself.
npm WARN @wix/wnp-bootstrap-express@1.0.2462 requires a peer of express@>=4.17.0 but none is installed. You must install peer dependencies yourself.
npm WARN @wix/wnp-bootstrap-proto-introspection@1.0.541 requires a peer of express@>=4.17.0 but none is installed. You must install peer dependencies yourself.
npm WARN @wix/wnp-bootstrap-rest-proto@1.0.1095 requires a peer of express@>=4.17.0 but none is installed. You must install peer dependencies yourself.
npm WARN @wix/wnp-bootstrap-rpc-server@1.0.1315 requires a peer of express@>=4.17.0 but none is installed. You must install peer dependencies yourself.
npm WARN express-async-errors@3.1.1 requires a peer of express@^4.16.2 but none is installed. You must install peer dependencies yourself.
npm WARN @wix/wix-express-proto@1.0.1163 requires a peer of express@>=4.17.0 but none is installed. You must install peer dependencies yourself.
npm WARN babel-plugin-transform-hmr-runtime@4.286.0 requires a peer of babel-core@^7.0.0-0 but none is installed. You must install peer dependencies yourself.
npm WARN tslint@6.1.3 requires a peer of typescript@>=2.3.0-dev || >=2.4.0-dev || >=2.5.0-dev || >=2.6.0-dev || >=2.7.0-dev || >=2.8.0-dev || >=2.9.0-dev || >=3.0.0-dev || >= 3.1.0-dev || >= 3.2.0-dev || >= 4.0.0-dev but none is installed. You must install peer dependencies yourself.
npm WARN tslint-config-yoshi-base@4.167.0 requires a peer of prettier@^2.0.5 but none is installed. You must install peer dependencies yourself.
npm WARN tslint-plugin-wix-style-react@1.0.9 requires a peer of tslint@^5.0.0 but none is installed. You must install peer dependencies yourself.
npm WARN tslint-plugin-wix-style-react@1.0.9 requires a peer of typescript@^2.4.0 but none is installed. You must install peer dependencies yourself.
npm WARN tslint-react-hooks@2.2.2 requires a peer of typescript@>=2.1.0 but none is installed. You must install peer dependencies yourself.
npm WARN tslint-react@4.1.0 requires a peer of tslint@^5.1.0 but none is installed. You must install peer dependencies yourself.
npm WARN tslint-react@4.1.0 requires a peer of typescript@>=2.8.0 but none is installed. You must install peer dependencies yourself.
npm WARN tsutils@3.20.0 requires a peer of typescript@>=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta but none is installed. You must install peer dependencies yourself.
npm WARN tslint-plugin-prettier@2.3.0 requires a peer of prettier@^1.9.0 || ^2.0.0 but none is installed. You must install peer dependencies yourself.
npm WARN eslint-plugin-prettier@2.7.0 requires a peer of prettier@>= 0.11.0 but none is installed. You must install peer dependencies yourself.
npm WARN graphql-tag@2.11.0 requires a peer of graphql@^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 but none is installed. You must install peer dependencies yourself.
npm WARN ts-loader@6.2.2 requires a peer of typescript@* but none is installed. You must install peer dependencies yourself.
npm WARN mdsvex@0.6.1 requires a peer of svelte@3.x but none is installed. You must install peer dependencies yourself.
npm WARN tslint@5.20.1 requires a peer of typescript@>=2.3.0-dev || >=2.4.0-dev || >=2.5.0-dev || >=2.6.0-dev || >=2.7.0-dev || >=2.8.0-dev || >=2.9.0-dev || >=3.0.0-dev || >= 3.1.0-dev || >= 3.2.0-dev but none is installed. You must install peer dependencies yourself.
npm WARN tsutils@2.29.0 requires a peer of typescript@>=2.1.0 || >=2.1.0-dev || >=2.2.0-dev || >=2.3.0-dev || >=2.4.0-dev || >=2.5.0-dev || >=2.6.0-dev || >=2.7.0-dev || >=2.8.0-dev || >=2.9.0-dev || >= 3.0.0-dev || >= 3.1.0-dev but none is installed. You must install peer dependencies yourself.
npm WARN tslint-config-yoshi@4.178.0 requires a peer of tslint-react-hooks@^2.1.0 but none is installed. You must install peer dependencies yourself.
npm WARN tsutils@3.20.0 requires a peer of typescript@>=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta but none is installed. You must install peer dependencies yourself.
npm WARN tslint-react@4.1.0 requires a peer of typescript@>=2.8.0 but none is installed. You must install peer dependencies yourself.
npm WARN tsutils@3.20.0 requires a peer of typescript@>=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta but none is installed. You must install peer dependencies yourself.
npm WARN tsutils@3.20.0 requires a peer of typescript@>=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta but none is installed. You must install peer dependencies yourself.




Output Log:
Migrating package "@wix/http2-test" in .


## Migration from non scope to @wix/scoped packages
> /tmp/45b9d442e745bb607ccbc8815a1dd5ea

#### rename package.json dependencies/dev/bundled/peer/optional, jest & eslintConfig
```
package.json
```

#### replace import/require in js/ts files
```
wallaby.js
src/server.js
src/components/App/App.js
```

> v8-profiler-node8@6.3.0 preinstall /tmp/45b9d442e745bb607ccbc8815a1dd5ea/node_modules/v8-profiler-node8
> node -e 'process.exit(0)'


> dtrace-provider@0.8.8 install /tmp/45b9d442e745bb607ccbc8815a1dd5ea/node_modules/dtrace-provider
> node-gyp rebuild || node suppress-error.js

make: Entering directory '/tmp/45b9d442e745bb607ccbc8815a1dd5ea/node_modules/dtrace-provider/build'
  TOUCH Release/obj.target/DTraceProviderStub.stamp
make: Leaving directory '/tmp/45b9d442e745bb607ccbc8815a1dd5ea/node_modules/dtrace-provider/build'

> @newrelic/native-metrics@6.0.0 install /tmp/45b9d442e745bb607ccbc8815a1dd5ea/node_modules/@newrelic/native-metrics
> node ./lib/pre-build.js install native_metrics

============================================================================
Attempting install in native-metrics module. Please note that this is an
OPTIONAL dependency, and any resultant errors in this process will not
affect the general performance of the New Relic agent, but event loop and
garbage collection metrics will not be collected.
============================================================================

> /usr/local/bin/node /usr/local/lib/node_modules/npm/node_modules/node-gyp/bin/node-gyp.js clean configure
> /usr/local/bin/node /usr/local/lib/node_modules/npm/node_modules/node-gyp/bin/node-gyp.js build -j 8 native_metrics
make: Entering directory '/tmp/45b9d442e745bb607ccbc8815a1dd5ea/node_modules/@newrelic/native-metrics/build'
  CXX(target) Release/obj.target/native_metrics/src/native_metrics.o
  CXX(target) Release/obj.target/native_metrics/src/GCBinder.o
  CXX(target) Release/obj.target/native_metrics/src/LoopChecker.o
  CXX(target) Release/obj.target/native_metrics/src/RUsageMeter.o
  SOLINK_MODULE(target) Release/obj.target/native_metrics.node
  COPY Release/native_metrics.node
make: Leaving directory '/tmp/45b9d442e745bb607ccbc8815a1dd5ea/node_modules/@newrelic/native-metrics/build'
install successful: _newrelic_native_metrics-6_0_0-native_metrics-72-linux-x64

> snappy@6.3.5 install /tmp/45b9d442e745bb607ccbc8815a1dd5ea/node_modules/snappy
> prebuild-install || node-gyp rebuild


> v8-profiler-node8@6.3.0 install /tmp/45b9d442e745bb607ccbc8815a1dd5ea/node_modules/v8-profiler-node8
> node-pre-gyp install --fallback-to-build

[v8-profiler-node8] Success: "/tmp/45b9d442e745bb607ccbc8815a1dd5ea/node_modules/v8-profiler-node8/build/binding/Release/node-v72-linux-x64/profiler.node" is installed via remote

> grpc@1.24.4 install /tmp/45b9d442e745bb607ccbc8815a1dd5ea/node_modules/grpc
> node-pre-gyp install --fallback-to-build --library=static_library

[grpc] Success: "/tmp/45b9d442e745bb607ccbc8815a1dd5ea/node_modules/grpc/src/node/extension_binary/node-v72-linux-x64-glibc/grpc_node.node" is installed via remote

> @wix/wix-bootstrap-greynode-config-template@1.0.630 postinstall /tmp/45b9d442e745bb607ccbc8815a1dd5ea/node_modules/@wix/wix-bootstrap-greynode-config-template
> copy-config-templates

copy-config-templates(@wix/wix-bootstrap-greynode-config-template): NODE_ENV='production', copying configs from '/tmp/45b9d442e745bb607ccbc8815a1dd5ea/node_modules/@wix/wix-bootstrap-greynode-config-template/templates' to '/templates'

> core-js@2.6.9 postinstall /tmp/45b9d442e745bb607ccbc8815a1dd5ea/node_modules/core-js
> node scripts/postinstall || echo "ignore"


> @wix/wnp-bootstrap-framework-config@1.0.27 postinstall /tmp/45b9d442e745bb607ccbc8815a1dd5ea/node_modules/@wix/wnp-bootstrap-framework-config
> copy-config-templates

copy-config-templates(@wix/wnp-bootstrap-framework-config): NODE_ENV='production', copying configs from '/tmp/45b9d442e745bb607ccbc8815a1dd5ea/node_modules/@wix/wnp-bootstrap-framework-config/templates' to '/templates'

> @wix/wnp-bootstrap-petri-specs@0.1.1747 postinstall /tmp/45b9d442e745bb607ccbc8815a1dd5ea/node_modules/@wix/wnp-bootstrap-petri-specs
> copy-config-templates

copy-config-templates(@wix/wnp-bootstrap-petri-specs): NODE_ENV='production', copying configs from '/tmp/45b9d442e745bb607ccbc8815a1dd5ea/node_modules/@wix/wnp-bootstrap-petri-specs/templates' to '/templates'

> @wix/wnp-bootstrap-statsd@1.0.1653 postinstall /tmp/45b9d442e745bb607ccbc8815a1dd5ea/node_modules/@wix/wnp-bootstrap-statsd
> copy-config-templates

copy-config-templates(@wix/wnp-bootstrap-statsd): NODE_ENV='production', copying configs from '/tmp/45b9d442e745bb607ccbc8815a1dd5ea/node_modules/@wix/wnp-bootstrap-statsd/templates' to '/templates'

> protobufjs@6.10.2 postinstall /tmp/45b9d442e745bb607ccbc8815a1dd5ea/node_modules/protobufjs
> node scripts/postinstall


> @wix/wnp-bootstrap-session@1.0.1724 postinstall /tmp/45b9d442e745bb607ccbc8815a1dd5ea/node_modules/@wix/wnp-bootstrap-session
> copy-config-templates

copy-config-templates(@wix/wnp-bootstrap-session): NODE_ENV='production', copying configs from '/tmp/45b9d442e745bb607ccbc8815a1dd5ea/node_modules/@wix/wnp-bootstrap-session/templates' to '/templates'

> @wix/wnp-bootstrap-petri@1.0.2081 postinstall /tmp/45b9d442e745bb607ccbc8815a1dd5ea/node_modules/@wix/wnp-bootstrap-petri
> copy-config-templates

copy-config-templates(@wix/wnp-bootstrap-petri): NODE_ENV='production', copying configs from '/tmp/45b9d442e745bb607ccbc8815a1dd5ea/node_modules/@wix/wnp-bootstrap-petri/templates' to '/templates'

> @wix/wnp-bootstrap-rpc-signing@1.0.1086 postinstall /tmp/45b9d442e745bb607ccbc8815a1dd5ea/node_modules/@wix/wnp-bootstrap-rpc-signing
> copy-config-templates

copy-config-templates(@wix/wnp-bootstrap-rpc-signing): NODE_ENV='production', copying configs from '/tmp/45b9d442e745bb607ccbc8815a1dd5ea/node_modules/@wix/wnp-bootstrap-rpc-signing/templates' to '/templates'

> @wix/wnp-bootstrap-consent-policy@1.0.79 postinstall /tmp/45b9d442e745bb607ccbc8815a1dd5ea/node_modules/@wix/wnp-bootstrap-consent-policy
> copy-config-templates

copy-config-templates(@wix/wnp-bootstrap-consent-policy): NODE_ENV='production', copying configs from '/tmp/45b9d442e745bb607ccbc8815a1dd5ea/node_modules/@wix/wnp-bootstrap-consent-policy/templates' to '/templates'

> @wix/wnp-identities-token@1.0.4 postinstall /tmp/45b9d442e745bb607ccbc8815a1dd5ea/node_modules/@wix/wnp-identities-token
> copy-config-templates

copy-config-templates(@wix/wnp-identities-token): NODE_ENV='production', copying configs from '/tmp/45b9d442e745bb607ccbc8815a1dd5ea/node_modules/@wix/wnp-identities-token/templates' to '/templates'

> @wix/wnp-bootstrap-aspects@1.0.1165 postinstall /tmp/45b9d442e745bb607ccbc8815a1dd5ea/node_modules/@wix/wnp-bootstrap-aspects
> copy-config-templates

copy-config-templates(@wix/wnp-bootstrap-aspects): NODE_ENV='production', copying configs from '/tmp/45b9d442e745bb607ccbc8815a1dd5ea/node_modules/@wix/wnp-bootstrap-aspects/templates' to '/templates'

> @wix/wnp-bootstrap-express@1.0.2462 postinstall /tmp/45b9d442e745bb607ccbc8815a1dd5ea/node_modules/@wix/wnp-bootstrap-express
> copy-config-templates

copy-config-templates(@wix/wnp-bootstrap-express): NODE_ENV='production', copying configs from '/tmp/45b9d442e745bb607ccbc8815a1dd5ea/node_modules/@wix/wnp-bootstrap-express/templates' to '/templates'

> @wix/wnp-bootstrap-tracing@1.0.976 postinstall /tmp/45b9d442e745bb607ccbc8815a1dd5ea/node_modules/@wix/wnp-bootstrap-tracing
> copy-config-templates

copy-config-templates(@wix/wnp-bootstrap-tracing): NODE_ENV='production', copying configs from '/tmp/45b9d442e745bb607ccbc8815a1dd5ea/node_modules/@wix/wnp-bootstrap-tracing/templates' to '/templates'

> @wix/wnp-bootstrap-grpc@1.0.1033 postinstall /tmp/45b9d442e745bb607ccbc8815a1dd5ea/node_modules/@wix/wnp-bootstrap-grpc
> copy-config-templates

copy-config-templates(@wix/wnp-bootstrap-grpc): NODE_ENV='production', copying configs from '/tmp/45b9d442e745bb607ccbc8815a1dd5ea/node_modules/@wix/wnp-bootstrap-grpc/templates' to '/templates'

> @wix/wnp-bootstrap-composer@0.1.4115 postinstall /tmp/45b9d442e745bb607ccbc8815a1dd5ea/node_modules/@wix/wnp-bootstrap-composer
> copy-config-templates

copy-config-templates(@wix/wnp-bootstrap-composer): NODE_ENV='production', copying configs from '/tmp/45b9d442e745bb607ccbc8815a1dd5ea/node_modules/@wix/wnp-bootstrap-composer/templates' to '/templates'

> @wix/wix-bootstrap-renderer@1.0.674 postinstall /tmp/45b9d442e745bb607ccbc8815a1dd5ea/node_modules/@wix/wix-bootstrap-renderer
> copy-config-templates

copy-config-templates(@wix/wix-bootstrap-renderer): NODE_ENV='production', copying configs from '/tmp/45b9d442e745bb607ccbc8815a1dd5ea/node_modules/@wix/wix-bootstrap-renderer/templates' to '/templates'
added 736 packages from 528 contributors and audited 4651 packages in 130.169s

8 packages are looking for funding
  run `npm fund` for details

found 373206 vulnerabilities (274092 low, 213 moderate, 98890 high, 11 critical)
  run `npm audit fix` to fix them, or `npm audit` for details

